### PR TITLE
fix: State.next; WINDOW_UPDATE :send

### DIFF
--- a/lib/biryani/state.rb
+++ b/lib/biryani/state.rb
@@ -100,12 +100,12 @@ module Biryani
       # receiving_data
       in [:receiving_data, FrameType::DATA, :recv] if frame.end_stream?
         :half_closed_remote
-      in [:receiving_data, FrameType::WINDOW_UPDATE, :recv]
-        state
       in [:receiving_data, FrameType::DATA, :recv]
         state
       in [:receiving_data, FrameType::RST_STREAM, _]
         :closed
+      in [:receiving_data, FrameType::WINDOW_UPDATE, _]
+        state
       in [:receiving_data, _, _]
         unexpected(ErrorCode::PROTOCOL_ERROR, state, typ, direction)
 
@@ -132,7 +132,7 @@ module Biryani
         state
       in [:half_closed_remote, FrameType::RST_STREAM, _]
         :closed
-      in [half_closed_remote, FrameType::WINDOW_UPDATE, :recv]
+      in [:half_closed_remote, FrameType::WINDOW_UPDATE, _]
         state
       in [:half_closed_remote, _, :recv]
         unexpected(ErrorCode::STREAM_CLOSED, state, typ, direction)


### PR DESCRIPTION
```
$ bundle exec ruby example/hello_world.rb
```

```
$ ruby -e "print 'a' * 65_536" | curl -X POST --data-binary @- --http2-prior-knowledge http://localhost:8888 -v
Note: Unnecessary use of -X or --request, POST is already inferred.
* Host localhost:8888 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:8888...
* Connected to localhost (::1) port 8888
* [HTTP/2] [1] OPENED stream for http://localhost:8888/
* [HTTP/2] [1] [:method: POST]
* [HTTP/2] [1] [:scheme: http]
* [HTTP/2] [1] [:authority: localhost:8888]
* [HTTP/2] [1] [:path: /]
* [HTTP/2] [1] [user-agent: curl/8.7.1]
* [HTTP/2] [1] [accept: */*]
* [HTTP/2] [1] [content-length: 65536]
* [HTTP/2] [1] [content-type: application/x-www-form-urlencoded]
> POST / HTTP/2
> Host: localhost:8888
> User-Agent: curl/8.7.1
> Accept: */*
> Content-Length: 65536
> Content-Type: application/x-www-form-urlencoded
>
* upload completely sent off: 65536 bytes
< HTTP/2 200
<
* Connection #0 to host localhost left intact
Hello, world!
```